### PR TITLE
Fix link to DCO in contributing.md

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -72,7 +72,7 @@ After your pull request has been reviewed and signed off, a maintainer will merg
 This project is managed under open governance model as described in our  [charter](https://www.hyperledger.org/about/charter). Projects or sub-projects will be lead by a set of maintainers. New projects can designate an initial set of maintainers that will be approved by the Technical Steering Committee when the project is first approved. The project's maintainers will, from time-to-time, consider adding a new maintainer. An existing maintainer will post a pull request to the [MAINTAINERS.txt](MAINTAINERS.txt) file. If a majority of the maintainers concur in the comments, the pull request is then merged and the individual becomes a maintainer.
 
 ## Legal stuff
-We have tried to make it as easy as possible to make contributions. This applies to how we handle the legal aspects of contribution. We use the same approach&mdash;the [Developer's Certificate of Origin 1.1 (DCO)](docs/biz/DCO1.1.txt)&mdash;that the Linux&reg; Kernel [community](http://elinux.org/Developer_Certificate_Of_Origin) uses to manage code contributions.
+We have tried to make it as easy as possible to make contributions. This applies to how we handle the legal aspects of contribution. We use the same approach&mdash;the [Developer's Certificate of Origin 1.1 (DCO)](http://developercertificate.org/)&mdash;that the Linux&reg; Kernel [community](http://elinux.org/Developer_Certificate_Of_Origin) uses to manage code contributions.
 We simply ask that when submitting a pull request, the developer must include a sign-off statement in the pull request description.
 
 Here is an example Signed-off-by line, which indicates that the submitter accepts the DCO:


### PR DESCRIPTION
Deleted broken link to https://github.com/hyperledger/fabric-api/blob/master/docs/docs/biz/DCO1.1.txt and replaced with link to http://developercertificate.org/

`Signed-off-by: Alice Ma <alicetyma@gmail.com>`