### PR TITLE
Add a PR and issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,5 @@
+## Description
+<!--- Describe your issue or user story in detail. -->
+
+## Describe How to Reproduce
+<!--- If an issue, provide sufficient context and steps to reproduce the issue -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+<!--- Provide a general summary of your changes in the Title above -->
+
+## Description
+<!--- Describe your changes in detail. -->
+
+## Motivation and Context
+<!--- Why is this change required? What problem does it solve? -->
+<!--- If it fixes an open issue, please link to the issue here. -->
+Fixes #
+
+## How Has This Been Tested?
+<!--- Please describe in detail how you tested your changes. -->
+<!--- If this PR does not contain a new test case, explain why. -->
+
+## Checklist:
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+- [ ] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
+- [ ] Either no new documentation is required by this change, OR I added new documentation
+- [ ] Either no new tests are required by this change, OR I added new tests
+
+Signed-off-by:


### PR DESCRIPTION
This change adds a GitHub PR and issue template, similar to the one already found at https://github.com/hyperledger/fabric. It gives basic instructions and asks submitters to verify that they've added testing, documentation, and a sign-off.

Signed-off-by: <sheehan@us.ibm.com>