### PR TITLE
Fix GRPCClientTest

### DIFF
--- a/api/src/main/java/org/hyperledger/api/HLAPITransaction.java
+++ b/api/src/main/java/org/hyperledger/api/HLAPITransaction.java
@@ -25,7 +25,7 @@ public class HLAPITransaction extends Transaction {
     private final BID blockID;
 
     public HLAPITransaction(Transaction transaction, BID blockID) {
-        super(transaction.getID(), transaction.getPayload());
+        super(transaction.getPayload());
         this.blockID = blockID;
     }
 

--- a/api/src/main/java/org/hyperledger/common/ByteUtils.java
+++ b/api/src/main/java/org/hyperledger/common/ByteUtils.java
@@ -104,7 +104,7 @@ public class ByteUtils {
      * @return
      */
     public static String toHex(byte[] data) {
-        return Hex.encodeHex(data).toString();
+        return new String(Hex.encodeHex(data));
     }
 
     /**

--- a/api/src/main/java/org/hyperledger/common/Transaction.java
+++ b/api/src/main/java/org/hyperledger/common/Transaction.java
@@ -21,8 +21,8 @@ public class Transaction implements MerkleTreeNode {
     private TID ID;
     private byte [] payload;
 
-    public Transaction(TID ID, byte [] payload) {
-        this.ID = ID;
+    public Transaction(byte [] payload) {
+        this.ID = new TID(Hash.of(payload));
         this.payload = payload;
     }
 

--- a/api/src/main/java/org/hyperledger/connector/GRPCClient.java
+++ b/api/src/main/java/org/hyperledger/connector/GRPCClient.java
@@ -159,7 +159,9 @@ public class GRPCClient implements HLAPI {
         ByteString result = query("getTran", Collections.singletonList(hexedHash));
         byte[] resultStr = result.toByteArray();
         if (resultStr.length == 0) return null;
-        return new HLAPITransaction(new Transaction(hash, resultStr), BID.INVALID);
+        Transaction t = new Transaction(resultStr);
+        if (!hash.equals(t.getID())) return null;
+        return new HLAPITransaction(new Transaction(resultStr), BID.INVALID);
     }
 
     @Override

--- a/api/src/main/java/org/hyperledger/connector/GRPCObserver.java
+++ b/api/src/main/java/org/hyperledger/connector/GRPCObserver.java
@@ -50,7 +50,7 @@ public class GRPCObserver {
                         Chaincode.ChaincodeInvocationSpec invocationSpec = Chaincode.ChaincodeInvocationSpec.parseFrom(invocationSpecBytes);
                         String transactionString = invocationSpec.getChaincodeSpec().getCtorMsg().getArgs(0);
                         byte[] transactionBytes = DatatypeConverter.parseBase64Binary(transactionString);
-                        HLAPITransaction tx = new HLAPITransaction(new Transaction(TID.INVALID, transactionBytes), BID.INVALID);
+                        HLAPITransaction tx = new HLAPITransaction(new Transaction(transactionBytes), BID.INVALID);
                         listener.process(tx);
                     } catch (HLAPIException | IOException e) {
                         e.printStackTrace();

--- a/api/src/test/java/org/hyperledger/connector/GRPCClientTest.java
+++ b/api/src/test/java/org/hyperledger/connector/GRPCClientTest.java
@@ -22,9 +22,7 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class GRPCClientTest {
     private static final Logger log = LoggerFactory.getLogger(GRPCClientTest.class);
@@ -54,7 +52,7 @@ public class GRPCClientTest {
 
     @Test
     public void sendTransaction() throws HLAPIException, InterruptedException {
-        Transaction tx = new Transaction(TID.INVALID, new byte[100]);
+        Transaction tx = new Transaction(new byte[100]);
 
         int originalHeight = client.getChainHeight();
         client.sendTransaction(tx);
@@ -62,7 +60,8 @@ public class GRPCClientTest {
         Thread.sleep(1500);
 
         HLAPITransaction res = client.getTransaction(tx.getID());
-        assertEquals(tx, res);
+        assertEquals(tx.getID(), res.getID());
+        assertArrayEquals(tx.getPayload(), res.getPayload());
         int newHeight = client.getChainHeight();
         assertTrue(newHeight == originalHeight + 1);
     }


### PR DESCRIPTION
Transaction now computes its own hash, and a bug is fixed in ByteUtils.

Signed-off-by: Zsolt Szilagyi <zsolt@digitalasset.com>

