### PR TITLE
Rejection events master

### DIFF
--- a/api/src/main/java/org/hyperledger/common/Hash.java
+++ b/api/src/main/java/org/hyperledger/common/Hash.java
@@ -18,6 +18,8 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 
+import org.apache.commons.codec.binary.Hex;
+
 /**
  * A Hash identifies objects, that is blocks and transactions, in the ledger.
  * Technically it is a double SHA256 digest of the object's content.
@@ -119,43 +121,28 @@ public class Hash {
     }
 
     /**
-     * return SHA256 hash of data
-     *
-     * @param data arbitary data
-     * @return SHA256(data)
-     */
-    public static byte[] sha256(byte[] data) {
-        try {
-            MessageDigest a = MessageDigest.getInstance("SHA-256");
-            return a.digest(data);
-        } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    /**
-     * Double SHA256 hash of arbitrary data
+     * SHA256 hash of arbitrary data
      *
      * @param data   arbitary data
      * @param offset start hashing at this offset (0 starts)
      * @param len    hash len number of bytes
-     * @return SHA256(SHA256(data))
+     * @return SHA256(data)
      */
     public static byte[] hash(byte[] data, int offset, int len) {
         try {
             MessageDigest a = MessageDigest.getInstance("SHA-256");
             a.update(data, offset, len);
-            return a.digest(a.digest());
+            return a.digest();
         } catch (NoSuchAlgorithmException e) {
             throw new RuntimeException(e);
         }
     }
 
     /**
-     * Double SHA256 hash of arbitrary data
+     * SHA256 hash of arbitrary data
      *
      * @param data arbitrary data
-     * @return SHA256(SHA256(data))
+     * @return SHA256(data)
      */
     public static byte[] hash(byte[] data) {
         return hash(data, 0, data.length);
@@ -169,6 +156,18 @@ public class Hash {
      */
     public static Hash of(byte[] data) {
         return new Hash(hash(data, 0, data.length));
+    }
+
+    /**
+     * UUID created from the first 128 bits of SHA256
+     *
+     * @return String
+     */
+    public String toUuidString() {
+            String result = String.join("-", contentAsHex(0, 4), contentAsHex(4, 6),
+                                             contentAsHex(6, 8), contentAsHex(8, 10),
+                                             contentAsHex(10, 16));
+            return result.toLowerCase();
     }
 
     /**
@@ -210,5 +209,9 @@ public class Hash {
         if (!Arrays.equals(bytes, hash.bytes)) return false;
 
         return true;
+    }
+
+    private String contentAsHex(int i, int j) {
+        return ByteUtils.toHex((Arrays.copyOfRange(bytes, i, j)));
     }
 }

--- a/api/src/main/java/org/hyperledger/common/Hash.java
+++ b/api/src/main/java/org/hyperledger/common/Hash.java
@@ -159,6 +159,17 @@ public class Hash {
     }
 
     /**
+     * Create a Hash from a UUID created from the first 128 bits of SHA256
+     *
+     * @return Hash
+     */
+    public static Hash fromUuidString(String uuidStr) {
+        String uuidWoDash = uuidStr.replaceAll("[-]", "");
+        byte[] uuidBytes = ByteUtils.fromHex(uuidWoDash);
+        return new Hash(Arrays.copyOf(uuidBytes, 32));
+    }
+
+    /**
      * UUID created from the first 128 bits of SHA256
      *
      * @return String
@@ -208,6 +219,18 @@ public class Hash {
 
         if (!Arrays.equals(bytes, hash.bytes)) return false;
 
+        return true;
+    }
+
+    public boolean equalsAsUuidString(Object o) {
+        if (this == o)
+            return true;
+        if (o == null)
+            return false;
+        if (!(o instanceof Hash))
+            return false;
+        Hash other = (Hash) o;
+        if (!toUuidString().equals(other.toUuidString())) return false;
         return true;
     }
 

--- a/api/src/main/java/org/hyperledger/common/Transaction.java
+++ b/api/src/main/java/org/hyperledger/common/Transaction.java
@@ -13,6 +13,8 @@
  */
 package org.hyperledger.common;
 
+import java.util.Arrays;
+
 /**
  * A transaction in the ledger.
  * A transaction reallocates inputs to outputs. Inputs are outputs of previous transactions.
@@ -34,7 +36,6 @@ public class Transaction implements MerkleTreeNode {
         return 0;
     }
 
-
     /**
      * get the Transaction ID
      *
@@ -46,5 +47,29 @@ public class Transaction implements MerkleTreeNode {
 
     public byte[] getPayload() {
         return payload;
+    }
+
+    @Override
+    public int hashCode() {
+        return this.ID.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (!(obj instanceof Transaction))
+            return false;
+        Transaction other = (Transaction) obj;
+        if (ID == null) {
+            if (other.ID != null)
+                return false;
+        } else if (!ID.equals(other.ID))
+            return false;
+        if (!Arrays.equals(payload, other.payload))
+            return false;
+        return true;
     }
 }

--- a/api/src/main/java/org/hyperledger/connector/GRPCClient.java
+++ b/api/src/main/java/org/hyperledger/connector/GRPCClient.java
@@ -49,7 +49,7 @@ import javax.xml.bind.DatatypeConverter;
 public class GRPCClient implements HLAPI {
     private static final Logger log = LoggerFactory.getLogger(GRPCClient.class);
 
-    final String chaincodeName = "noop";
+    final String chaincodeName = "noop_syscc";
 
 
     private DevopsBlockingStub dbs;

--- a/api/src/main/java/org/hyperledger/connector/GRPCClient.java
+++ b/api/src/main/java/org/hyperledger/connector/GRPCClient.java
@@ -67,14 +67,18 @@ public class GRPCClient implements HLAPI {
         observer.connect();
     }
 
-    public void invoke(String chaincodeName, byte[] transaction) {
-        String encodedTransaction = Base64.getEncoder().encodeToString(transaction);
+    public void invoke(String chaincodeName, Transaction transaction) {
+        invoke(chaincodeName, "execute", transaction);
+    }
+
+    public void invoke(String chaincodeName, String functionName, Transaction transaction) {
+        String encodedTransaction = Base64.getEncoder().encodeToString(transaction.getPayload());
 
         ChaincodeID.Builder chaincodeId = ChaincodeID.newBuilder();
         chaincodeId.setName(chaincodeName);
 
         ChaincodeInput.Builder chaincodeInput = ChaincodeInput.newBuilder();
-        chaincodeInput.setFunction("execute");
+        chaincodeInput.setFunction(functionName);
         chaincodeInput.addArgs(encodedTransaction);
 
         ChaincodeSpec.Builder chaincodeSpec = ChaincodeSpec.newBuilder();
@@ -82,7 +86,7 @@ public class GRPCClient implements HLAPI {
         chaincodeSpec.setCtorMsg(chaincodeInput);
 
         ChaincodeInvocationSpec.Builder chaincodeInvocationSpec = ChaincodeInvocationSpec.newBuilder();
-        chaincodeInvocationSpec.setChaincodeSpec(chaincodeSpec);
+        chaincodeInvocationSpec.setChaincodeSpec(chaincodeSpec).setUuidGenerationAlg("sha256base64");
 
         dbs.invoke(chaincodeInvocationSpec.build());
     }
@@ -155,8 +159,7 @@ public class GRPCClient implements HLAPI {
 
     @Override
     public HLAPITransaction getTransaction(TID hash) throws HLAPIException {
-        String hexedHash = ByteUtils.toHex(hash.toByteArray());
-        ByteString result = query("getTran", Collections.singletonList(hexedHash));
+        ByteString result = query("getTran", Collections.singletonList(hash.toUuidString().toLowerCase()));
         byte[] resultStr = result.toByteArray();
         if (resultStr.length == 0) return null;
         Transaction t = new Transaction(resultStr);
@@ -166,17 +169,17 @@ public class GRPCClient implements HLAPI {
 
     @Override
     public void sendTransaction(Transaction transaction) throws HLAPIException {
-        invoke(chaincodeName, transaction.getPayload());
+        invoke(chaincodeName, transaction);
     }
 
     @Override
     public void registerRejectListener(RejectListener rejectListener) throws HLAPIException {
-        throw new UnsupportedOperationException();
+        observer.subscribeToRejections(rejectListener);
     }
 
     @Override
     public void removeRejectListener(RejectListener rejectListener) {
-        throw new UnsupportedOperationException();
+        observer.unsubscribeFromRejections(rejectListener);
     }
 
 
@@ -187,22 +190,22 @@ public class GRPCClient implements HLAPI {
 
     @Override
     public void registerTransactionListener(TransactionListener listener) throws HLAPIException {
-        observer.subscribe(listener);
+        observer.subscribeToTransactions(listener);
     }
 
     @Override
     public void removeTransactionListener(TransactionListener listener) {
-        observer.unsubscribe(listener);
+        observer.unsubscribeFromTransactions(listener);
     }
 
     @Override
     public void registerTrunkListener(TrunkListener listener) throws HLAPIException {
-        throw new UnsupportedOperationException();
+       observer.subscribeToBlocks(listener);
     }
 
     @Override
     public void removeTrunkListener(TrunkListener listener) {
-        throw new UnsupportedOperationException();
+        observer.unsubscribeFromBlocks(listener);
     }
 
     @Override

--- a/api/src/main/java/org/hyperledger/connector/GRPCObserver.java
+++ b/api/src/main/java/org/hyperledger/connector/GRPCObserver.java
@@ -15,21 +15,24 @@
 package org.hyperledger.connector;
 
 import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
+
 import io.grpc.Channel;
 import io.grpc.stub.StreamObserver;
 import org.hyperledger.api.HLAPIException;
 import org.hyperledger.api.HLAPITransaction;
 import org.hyperledger.api.TransactionListener;
 import org.hyperledger.common.BID;
-import org.hyperledger.common.TID;
 import org.hyperledger.common.Transaction;
 import protos.Chaincode;
 import protos.EventsGrpc;
 import protos.EventsOuterClass;
+import protos.Fabric.Block;
 
 import javax.xml.bind.DatatypeConverter;
 import java.io.IOException;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 public class GRPCObserver {
@@ -46,17 +49,26 @@ public class GRPCObserver {
             public void onNext(EventsOuterClass.Event openchainEvent) {
                 listeners.forEach((listener) -> {
                     try {
-                        ByteString invocationSpecBytes = openchainEvent.getBlock().getTransactions(0).getPayload();
-                        Chaincode.ChaincodeInvocationSpec invocationSpec = Chaincode.ChaincodeInvocationSpec.parseFrom(invocationSpecBytes);
-                        String transactionString = invocationSpec.getChaincodeSpec().getCtorMsg().getArgs(0);
-                        byte[] transactionBytes = DatatypeConverter.parseBase64Binary(transactionString);
-                        HLAPITransaction tx = new HLAPITransaction(new Transaction(transactionBytes), BID.INVALID);
-                        listener.process(tx);
+                        if (openchainEvent.getEventCase() == EventsOuterClass.Event.EventCase.BLOCK) {
+                            Block block = openchainEvent.getBlock();
+                            processAll(listener, block.getTransactionsList());
+                        }
                     } catch (HLAPIException | IOException e) {
                         e.printStackTrace();
                     }
                 });
                 System.out.println("new event: " + openchainEvent.toString());
+            }
+
+            private void processAll(TransactionListener listener, List<protos.Fabric.Transaction> transactionsList) throws HLAPIException, InvalidProtocolBufferException {
+                for(protos.Fabric.Transaction tx : transactionsList) {
+                    ByteString invocationSpecBytes = tx.getPayload();
+                    Chaincode.ChaincodeInvocationSpec invocationSpec = Chaincode.ChaincodeInvocationSpec.parseFrom(invocationSpecBytes);
+                    String transactionString = invocationSpec.getChaincodeSpec().getCtorMsg().getArgs(0);
+                    byte[] transactionBytes = DatatypeConverter.parseBase64Binary(transactionString);
+                    HLAPITransaction hlapitx = new HLAPITransaction(new Transaction(transactionBytes), BID.INVALID);
+                    listener.process(hlapitx);
+                }
             }
 
             @Override

--- a/api/src/main/proto/chaincode.proto
+++ b/api/src/main/proto/chaincode.proto
@@ -94,9 +94,13 @@ message ChaincodeInvocationSpec {
 
     ChaincodeSpec chaincodeSpec = 1;
     //ChaincodeInput message = 2;
-
+    string userGivenID = 2;
 }
 
+// This structure contain transaction data that we send to the chaincode
+// container shim and allow the chaincode to access through the shim interface.
+// TODO: Consider remove this message and just pass the transaction object
+// to the shim and/or allow the chaincode to query transactions.
 message ChaincodeSecurityContext {
     bytes callerCert = 1;
     bytes callerSign = 2;
@@ -104,6 +108,7 @@ message ChaincodeSecurityContext {
     bytes binding = 4;
     bytes metadata = 5;
     bytes parentMetadata = 6;
+    google.protobuf.Timestamp txTimestamp = 7; // transaction timestamp
 }
 
 message ChaincodeMessage {

--- a/api/src/main/proto/chaincode.proto
+++ b/api/src/main/proto/chaincode.proto
@@ -94,7 +94,14 @@ message ChaincodeInvocationSpec {
 
     ChaincodeSpec chaincodeSpec = 1;
     //ChaincodeInput message = 2;
-    string userGivenID = 2;
+    // This field can contain a user-specified UUID generation algorithm
+    // If supplied, this will be used to generate a UUID
+    // If not supplied (left empty), a random UUID will be generated
+    // The algorithm consists of two parts:
+    //  1, a hash function
+    //  2, a decoding used to decode user (string) input to bytes
+    // Currently, SHA256 with BASE64 is supported (e.g. uuidGenerationAlg='sha256base64')
+    string uuidGenerationAlg = 2;
 }
 
 // This structure contain transaction data that we send to the chaincode

--- a/api/src/main/proto/chaincode.proto
+++ b/api/src/main/proto/chaincode.proto
@@ -93,7 +93,6 @@ message ChaincodeDeploymentSpec {
 message ChaincodeInvocationSpec {
 
     ChaincodeSpec chaincodeSpec = 1;
-    //ChaincodeInput message = 2;
     // This field can contain a user-specified UUID generation algorithm
     // If supplied, this will be used to generate a UUID
     // If not supplied (left empty), a random UUID will be generated

--- a/api/src/main/proto/events.proto
+++ b/api/src/main/proto/events.proto
@@ -44,6 +44,14 @@ message Register {
     repeated Interest events = 1;
 }
 
+
+//Rejection is sent by consumers for erroneous transaction rejection events
+//string type - "rejection"
+message Rejection {
+    string Uuid = 1;
+    string ErrorMsg = 2;
+}
+
 //---------- producer events ---------
 //Generic is used for encoding payload as JSON or raw bytes
 //string type - "generic"
@@ -64,6 +72,7 @@ message Event {
         //producer events
         Block block = 2;
         Generic generic = 3;
+        Rejection rejection = 4;
     }
 }
 

--- a/api/src/main/proto/fabric.proto
+++ b/api/src/main/proto/fabric.proto
@@ -201,8 +201,9 @@ message BlockState {
 // example, if start=3 and end=5, the order of blocks will be 3, 4, 5.
 // If start=5 and end=3, the order will be 5, 4, 3.
 message SyncBlockRange {
-    uint64 start = 1;
-    uint64 end = 2;
+    uint64 correlationId = 1;
+    uint64 start = 2;
+    uint64 end = 3;
 }
 // SyncBlocks is the payload of Message.SYNC_BLOCKS, where the range
 // indicates the blocks responded to the request SYNC_GET_BLOCKS

--- a/api/src/test/java/org/hyperledger/connector/GRPCClientTest.java
+++ b/api/src/test/java/org/hyperledger/connector/GRPCClientTest.java
@@ -13,16 +13,27 @@
  */
 package org.hyperledger.connector;
 
+import org.hyperledger.api.HLAPIBlock;
 import org.hyperledger.api.HLAPIException;
 import org.hyperledger.api.HLAPITransaction;
+import org.hyperledger.api.RejectListener;
 import org.hyperledger.api.TransactionListener;
+import org.hyperledger.api.TrunkListener;
 import org.hyperledger.common.*;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.grpc.StatusRuntimeException;
+
 import static org.junit.Assert.*;
+
+import java.util.List;
+
+import org.hamcrest.CoreMatchers;
 
 public class GRPCClientTest {
     private static final Logger log = LoggerFactory.getLogger(GRPCClientTest.class);
@@ -43,10 +54,14 @@ public class GRPCClientTest {
         assertTrue(height > 0);
     }
 
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
     @Test
     public void getNonExistingTransaction() throws HLAPIException {
-        HLAPITransaction res = client.getTransaction(TID.INVALID);
-        assertTrue(res == null);
+        thrown.expect(StatusRuntimeException.class);
+        thrown.expectMessage(CoreMatchers.containsString("ledger: resource not found"));
+        client.getTransaction(TID.INVALID);
     }
 
     @Test
@@ -57,7 +72,6 @@ public class GRPCClientTest {
         client.sendTransaction(tx);
 
         Thread.sleep(1500);
-
         HLAPITransaction res = client.getTransaction(tx.getID());
         assertEquals(tx.getID(), res.getID());
         assertArrayEquals(tx.getPayload(), res.getPayload());
@@ -69,6 +83,7 @@ public class GRPCClientTest {
     public void transactionListener() throws HLAPIException, InterruptedException {
         Transaction tx1 = new Transaction(new byte[100]);
         Transaction tx2 = new Transaction(new byte[90]);
+        Transaction tx3 = new Transaction(new byte[95]);
         class TestListener implements TransactionListener {
             private byte processedTxCount = 0;
 
@@ -88,6 +103,7 @@ public class GRPCClientTest {
 
         client.sendTransaction(tx1);
         client.sendTransaction(tx2);
+        client.invoke(client.chaincodeName, "some-fake-function-name", tx3);
 
         byte expectedTxCount = 2;
         byte counter = 3;
@@ -97,6 +113,81 @@ public class GRPCClientTest {
           counter--;
         }
         client.removeTransactionListener(listener);
+        assertEquals(expectedTxCount, listener.getProcessedTxCount());
+    }
+
+    @Test
+    public void trunkListener() throws HLAPIException, InterruptedException {
+        Transaction tx1 = new Transaction(new byte[100]);
+        Transaction tx2 = new Transaction(new byte[90]);
+        class TestListener implements TrunkListener {
+            private byte processedBlockCount = 0;
+            private byte processedTxCount = 0;
+
+            public byte getProcessedTxCount() {
+                return processedTxCount;
+            }
+
+            public byte getProcessedBlockCount() {
+                return processedBlockCount;
+            }
+
+            @Override
+            public void trunkUpdate(List<HLAPIBlock> added) {
+                processedBlockCount += added.size();
+                for(HLAPIBlock b : added) {
+                    processedTxCount += b.getTransactions().size();
+                }
+            }
+        };
+        TestListener listener = new TestListener();
+        client.registerTrunkListener(listener);
+        client.invoke(client.chaincodeName, "some-fake-function-name", tx1);
+        client.sendTransaction(tx2);
+
+        byte expectedBlockCount = 1;
+        byte expectedTxCount = 2;
+        byte counter = 3;
+        while(counter != 0 && expectedTxCount != listener.getProcessedTxCount())
+        {
+          Thread.sleep(1000);
+          counter--;
+        }
+        client.removeTrunkListener(listener);
+        assertEquals(expectedBlockCount, listener.getProcessedBlockCount());
+        assertEquals(expectedTxCount, listener.getProcessedTxCount());
+    }
+
+    @Test
+    public void rejectListener() throws HLAPIException, InterruptedException {
+        Transaction tx1 = new Transaction(new byte[100]);
+        Transaction tx2 = new Transaction(new byte[90]);
+        class TestListener implements RejectListener {
+            private byte processedRejectionCount = 0;
+
+            public byte getProcessedTxCount() {
+                return processedRejectionCount;
+            }
+
+            @Override
+            public void rejected(String command, Hash hash, String reason, int rejectionCode) {
+                processedRejectionCount++;
+            }
+        };
+        TestListener listener = new TestListener();
+        client.registerRejectListener(listener);
+
+        client.invoke(client.chaincodeName, "some-fake-function-name", tx1);
+        client.sendTransaction(tx2);
+
+        byte expectedTxCount = 1;
+        byte counter = 3;
+        while(counter != 0 && expectedTxCount != listener.getProcessedTxCount())
+        {
+          Thread.sleep(1000);
+          counter--;
+        }
+        client.removeRejectListener(listener);
         assertEquals(expectedTxCount, listener.getProcessedTxCount());
     }
 

--- a/api/src/test/java/org/hyperledger/connector/GRPCClientTest.java
+++ b/api/src/test/java/org/hyperledger/connector/GRPCClientTest.java
@@ -31,6 +31,8 @@ import io.grpc.StatusRuntimeException;
 
 import static org.junit.Assert.*;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.hamcrest.CoreMatchers;
@@ -105,7 +107,7 @@ public class GRPCClientTest {
         client.sendTransaction(tx2);
         client.invoke(client.chaincodeName, "some-fake-function-name", tx3);
 
-        byte expectedTxCount = 2;
+        byte expectedTxCount = 3;
         byte counter = 3;
         while(counter != 0 && expectedTxCount != listener.getProcessedTxCount())
         {
@@ -164,6 +166,7 @@ public class GRPCClientTest {
         Transaction tx2 = new Transaction(new byte[90]);
         class TestListener implements RejectListener {
             private byte processedRejectionCount = 0;
+            List<Hash> rejectedTXs = Collections.synchronizedList(new ArrayList<Hash>(5));
 
             public byte getProcessedTxCount() {
                 return processedRejectionCount;
@@ -172,6 +175,7 @@ public class GRPCClientTest {
             @Override
             public void rejected(String command, Hash hash, String reason, int rejectionCode) {
                 processedRejectionCount++;
+                rejectedTXs.add(hash);
             }
         };
         TestListener listener = new TestListener();
@@ -184,11 +188,12 @@ public class GRPCClientTest {
         byte counter = 3;
         while(counter != 0 && expectedTxCount != listener.getProcessedTxCount())
         {
-          Thread.sleep(1000);
-          counter--;
+            Thread.sleep(1000);
+            counter--;
         }
         client.removeRejectListener(listener);
         assertEquals(expectedTxCount, listener.getProcessedTxCount());
+        assertTrue(((Hash)listener.rejectedTXs.get(0)).equalsAsUuidString(tx1.getID()));
     }
 
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This commit adds modifications which make fabric-api able to work with the following modifications of fabric:
- add noop system chaincode (https://github.com/hyperledger/fabric/pull/1722)
- add content generated TxUUID (https://github.com/hyperledger/fabric/pull/1721)
- add rejection events (https://github.com/hyperledger/fabric/pull/1754)

## Description
See the summary.

## Motivation and Context
The motivation behind this commit is to make the API work with the newest modifications of fabric.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- If this PR does not contain a new test case, explain why. -->
Unit tests were added and run.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests

Signed-off-by: Gabor Hosszu <gabor@digitalasset.com>
