### PR TITLE
Add transaction serialization

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -75,6 +75,19 @@
                     </replacements>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.avro</groupId>
+                <artifactId>avro-maven-plugin</artifactId>
+                <version>${avro.version}</version>
+                <executions>
+                    <execution>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>schema</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 
@@ -102,6 +115,14 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jul-to-slf4j</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk15on</artifactId>
         </dependency>
      </dependencies>
 </project>

--- a/api/src/main/avro/transaction.avsc
+++ b/api/src/main/avro/transaction.avsc
@@ -1,0 +1,9 @@
+{
+    "namespace": "org.hyperledger.transaction",
+    "type": "record",
+    "name": "SerializedTransaction",
+    "fields": [
+        { "name": "payload",    "type": "bytes" },
+        { "name": "endorsers",  "type": { "type": "array", "items": "bytes" }}
+    ]
+}

--- a/api/src/main/java/org/hyperledger/api/HLAPITransaction.java
+++ b/api/src/main/java/org/hyperledger/api/HLAPITransaction.java
@@ -21,7 +21,7 @@ public class HLAPITransaction extends Transaction {
     private final BID blockID;
 
     public HLAPITransaction(Transaction transaction, BID blockID) {
-        super(transaction.getPayload());
+        super(transaction);
         this.blockID = blockID;
     }
 

--- a/api/src/main/java/org/hyperledger/api/connector/GRPCObserver.java
+++ b/api/src/main/java/org/hyperledger/api/connector/GRPCObserver.java
@@ -49,7 +49,7 @@ public class GRPCObserver {
                         Chaincode.ChaincodeInvocationSpec invocationSpec = Chaincode.ChaincodeInvocationSpec.parseFrom(invocationSpecBytes);
                         String transactionString = invocationSpec.getChaincodeSpec().getCtorMsg().getArgs(0);
                         byte[] transactionBytes = DatatypeConverter.parseBase64Binary(transactionString);
-                        HLAPITransaction tx = new HLAPITransaction(new Transaction(transactionBytes), BID.INVALID);
+                        HLAPITransaction tx = new HLAPITransaction(Transaction.fromByteArray(transactionBytes), BID.INVALID);
                         listener.process(tx);
                     } catch (HLAPIException | IOException e) {
                         e.printStackTrace();

--- a/api/src/main/java/org/hyperledger/common/BouncyCastleCrypto.java
+++ b/api/src/main/java/org/hyperledger/common/BouncyCastleCrypto.java
@@ -1,0 +1,136 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.hyperledger.common;
+
+import org.bouncycastle.asn1.ASN1InputStream;
+import org.bouncycastle.asn1.ASN1Integer;
+import org.bouncycastle.asn1.DERSequenceGenerator;
+import org.bouncycastle.asn1.DLSequence;
+import org.bouncycastle.asn1.sec.SECNamedCurves;
+import org.bouncycastle.asn1.x9.X9ECParameters;
+import org.bouncycastle.crypto.AsymmetricCipherKeyPair;
+import org.bouncycastle.crypto.digests.SHA256Digest;
+import org.bouncycastle.crypto.generators.ECKeyPairGenerator;
+import org.bouncycastle.crypto.params.ECDomainParameters;
+import org.bouncycastle.crypto.params.ECKeyGenerationParameters;
+import org.bouncycastle.crypto.params.ECPrivateKeyParameters;
+import org.bouncycastle.crypto.params.ECPublicKeyParameters;
+import org.bouncycastle.crypto.signers.ECDSASigner;
+import org.bouncycastle.crypto.signers.HMacDSAKCalculator;
+import org.bouncycastle.math.ec.ECPoint;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.math.BigInteger;
+import java.security.SecureRandom;
+
+public class BouncyCastleCrypto implements Cryptography {
+
+    static final X9ECParameters curve = SECNamedCurves.getByName("secp256k1");
+    static final ECDomainParameters domain = new ECDomainParameters(curve.getCurve(), curve.getG(), curve.getN(), curve.getH());
+    static final SecureRandom secureRandom = new SecureRandom();
+    static final BigInteger HALF_CURVE_ORDER = curve.getN().shiftRight(1);
+
+    @Override
+    public byte[] createNewPrivateKey() {
+        ECKeyPairGenerator generator = new ECKeyPairGenerator();
+        ECKeyGenerationParameters keygenParams = new ECKeyGenerationParameters(domain, secureRandom);
+        generator.init(keygenParams);
+        AsymmetricCipherKeyPair keypair = generator.generateKeyPair();
+        ECPrivateKeyParameters privParams = (ECPrivateKeyParameters) keypair.getPrivate();
+        return privParams.getD().toByteArray();
+    }
+
+    @Override
+    public byte[] getPublicFor(byte[] privateKey) {
+        return curve.getG().multiply(new BigInteger(privateKey)).getEncoded(true);
+    }
+
+    @Override
+    public byte[] getPrivateKeyAtOffset(byte[] privateKey, byte[] offset) {
+        return new BigInteger(offset).add(new BigInteger(privateKey)).mod(curve.getN()).toByteArray();
+    }
+
+    @Override
+    public byte[] uncompressPoint(byte[] compressed) {
+        return curve.getCurve().decodePoint(compressed).getEncoded(false);
+    }
+
+    @Override
+    public byte[] getPublicKeyAtOffset(byte[] publicKey, byte[] offset) {
+        BigInteger offsetInt = new BigInteger(publicKey);
+        boolean invert = false;
+
+        if (offsetInt.compareTo(BigInteger.ZERO) < 0) {
+            invert = true;
+            offsetInt = offsetInt.abs();
+        }
+
+        ECPoint oG = curve.getG().multiply(offsetInt);
+
+        if (invert) {
+            oG = oG.negate();
+        }
+
+        return oG.add(curve.getCurve().decodePoint(publicKey)).getEncoded(true);
+    }
+
+    @Override
+    public byte[] sign(byte[] hash, byte[] privateKey) {
+        ECDSASigner signer = new ECDSASigner(new HMacDSAKCalculator(new SHA256Digest()));
+        signer.init(true, new ECPrivateKeyParameters(new BigInteger(privateKey), domain));
+        BigInteger[] signature = signer.generateSignature(hash);
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try {
+            DERSequenceGenerator seq = new DERSequenceGenerator(baos);
+            seq.addObject(new ASN1Integer(signature[0]));
+            seq.addObject(new ASN1Integer(toCanonicalS(signature[1])));
+            seq.close();
+            return baos.toByteArray();
+        } catch (IOException e) {
+            return new byte[0];
+        }
+    }
+
+    private BigInteger toCanonicalS(BigInteger s) {
+        if (s.compareTo(HALF_CURVE_ORDER) <= 0) {
+            return s;
+        } else {
+            return curve.getN().subtract(s);
+        }
+    }
+
+    @Override
+    public boolean verify(byte[] hash, byte[] signature, byte[] publicKey) {
+        ASN1InputStream asn1 = new ASN1InputStream(signature);
+        try {
+            ECDSASigner signer = new ECDSASigner();
+            signer.init(false, new ECPublicKeyParameters(curve.getCurve().decodePoint(publicKey), domain));
+
+            DLSequence seq = (DLSequence) asn1.readObject();
+            BigInteger r = ((ASN1Integer) seq.getObjectAt(0)).getPositiveValue();
+            BigInteger s = ((ASN1Integer) seq.getObjectAt(1)).getPositiveValue();
+            return signer.verifySignature(hash, r, s);
+        } catch (Exception e) {
+            return false;
+        } finally {
+            try {
+                asn1.close();
+            } catch (IOException ignored) {
+            }
+        }
+    }
+
+}

--- a/api/src/main/java/org/hyperledger/common/Cryptography.java
+++ b/api/src/main/java/org/hyperledger/common/Cryptography.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.hyperledger.common;
+
+public interface Cryptography {
+
+    byte[] createNewPrivateKey();
+
+    byte[] getPublicFor(byte[] privateKey);
+
+    byte[] getPrivateKeyAtOffset(byte[] privateKey, byte[] offset);
+
+    byte[] uncompressPoint(byte[] compressed);
+
+    byte[] getPublicKeyAtOffset(byte[] publicKey, byte[] offset);
+
+    byte[] sign(byte[] hash, byte[] privateKey);
+
+    boolean verify(byte[] hash, byte[] signature, byte[] publicKey);
+
+}

--- a/api/src/main/java/org/hyperledger/common/Key.java
+++ b/api/src/main/java/org/hyperledger/common/Key.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hyperledger.common;
+
+import java.math.BigInteger;
+
+/**
+ * An ECC public or private key
+ */
+public interface Key {
+
+    /**
+     * Safe access to the key's internal representation
+     *
+     * @return a copy of the key's internal representation
+     */
+    byte[] toByteArray();
+
+    /**
+     * Return a key computable for this key with an offset.
+     * Due to a homomorphic property of EC one may compute the offset key of
+     * both private and public keys independently such that they build a valid new pair.
+     *
+     * @param offset
+     * @return a key derived of this with an offset.
+     */
+    Key offsetKey(BigInteger offset);
+}

--- a/api/src/main/java/org/hyperledger/common/PrivateKey.java
+++ b/api/src/main/java/org/hyperledger/common/PrivateKey.java
@@ -1,0 +1,96 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.hyperledger.common;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+
+/**
+ * An EC Private Key, technically a big positive integer capable of signing such that the signature can be verified
+ * with the corresponding EC Public Key
+ *
+ * @see PublicKey
+ */
+public class PrivateKey implements Key {
+    private static final Logger log = LoggerFactory.getLogger(PrivateKey.class);
+
+    private final byte[] priv;
+    private final Cryptography crypto;
+    private PublicKey publicKey = null; // lazy initialization
+
+    /**
+     * Create from uncompressed binary representation
+     */
+    private PrivateKey(byte[] priv, Cryptography crypto) {
+        this.priv = priv;
+        this.crypto = crypto;
+    }
+
+    public static PrivateKey createNew(Cryptography crypto) {
+        return new PrivateKey(crypto.createNewPrivateKey(), crypto);
+    }
+
+    @Override
+    public byte[] toByteArray() {
+        return priv.clone();
+    }
+
+    /**
+     * @return the corresponding public key
+     */
+    public PublicKey getPublic() {
+        if (publicKey == null) {
+            publicKey = new PublicKey(crypto.getPublicFor(priv), crypto);
+        }
+        return publicKey;
+    }
+
+    /**
+     * Sign a digest with this key.
+     *
+     * @param hash arbitrary data
+     * @return signature
+     */
+    public byte[] sign(byte[] hash) {
+        return crypto.sign(hash, toByteArray());
+    }
+
+    @Override
+    public String toString() {
+        return "private key of " + getPublic();
+    }
+
+    @Override
+    public PrivateKey offsetKey(BigInteger offset) {
+        return new PrivateKey(crypto.getPrivateKeyAtOffset(priv, offset.toByteArray()), crypto);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(priv);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof PrivateKey) {
+            PrivateKey other = (PrivateKey) obj;
+            return Arrays.equals(priv, other.priv);
+        }
+        return false;
+    }
+}

--- a/api/src/main/java/org/hyperledger/common/PublicKey.java
+++ b/api/src/main/java/org/hyperledger/common/PublicKey.java
@@ -1,0 +1,82 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.hyperledger.common;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+
+/**
+ * An EC public Key suitable for verifying a signature created with the corresponding EC PrivateKey
+ *
+ * @see PrivateKey
+ */
+public class PublicKey implements Key {
+    private final Cryptography crypto;
+    private final byte[] pub;
+
+    /**
+     * Create from uncompressed binary representation
+     */
+    public PublicKey(byte[] pub, Cryptography crypto) {
+        this.pub = pub;
+        this.crypto = crypto;
+    }
+
+    public static PublicKey fromCompressed(byte[] pub, Cryptography crypto) {
+        return new PublicKey(crypto.uncompressPoint(pub), crypto);
+    }
+
+    @Override
+    public byte[] toByteArray() {
+        return pub.clone();
+    }
+
+    /**
+     * verify a signature created with the private counterpart of this key
+     *
+     * @param hash      arbitrary data
+     * @param signature signature
+     * @return true if valid
+     */
+    public boolean verify(byte[] hash, byte[] signature) {
+        return crypto.verify(hash, signature, pub);
+    }
+
+    @Override
+    public PublicKey offsetKey(BigInteger offset) {
+        byte[] atOffset = crypto.getPublicKeyAtOffset(pub, offset.toByteArray());
+        return fromCompressed(atOffset, crypto);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(pub);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof PublicKey) {
+            PublicKey other = (PublicKey) obj;
+            return Arrays.equals(this.pub, other.pub);
+        }
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        return ByteUtils.toHex(pub);
+    }
+
+}

--- a/api/src/main/java/org/hyperledger/transaction/AvroSerializer.java
+++ b/api/src/main/java/org/hyperledger/transaction/AvroSerializer.java
@@ -1,0 +1,43 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.hyperledger.transaction;
+
+import org.apache.avro.Schema;
+import org.apache.avro.io.*;
+import org.apache.avro.specific.SpecificDatumReader;
+import org.apache.avro.specific.SpecificDatumWriter;
+import org.apache.avro.specific.SpecificRecord;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+public class AvroSerializer {
+
+    public static <T extends SpecificRecord> byte[] serialize(T data) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        BinaryEncoder encoder = EncoderFactory.get().binaryEncoder(out, null);
+        DatumWriter<T> writer = new SpecificDatumWriter<>(data.getSchema());
+        writer.write(data, encoder);
+        encoder.flush();
+        out.close();
+        return out.toByteArray();
+    }
+
+    public static <T extends SpecificRecord> T deserialize(byte[] data, Schema schema) throws IOException {
+        SpecificDatumReader<T> reader = new SpecificDatumReader<>(schema);
+        Decoder decoder = DecoderFactory.get().binaryDecoder(data, null);
+        return reader.read(null, decoder);
+    }
+}

--- a/api/src/main/java/org/hyperledger/transaction/Endorser.java
+++ b/api/src/main/java/org/hyperledger/transaction/Endorser.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.hyperledger.transaction;
+
+import org.hyperledger.common.PrivateKey;
+import org.hyperledger.common.PublicKey;
+
+public class Endorser {
+
+    private final byte[] signature;
+
+    public Endorser(byte[] signature) {
+        this.signature = signature;
+    }
+
+    public static Endorser create(byte[] hash, PrivateKey key) {
+        return new Endorser(key.sign(hash));
+    }
+
+    public boolean verify(byte[] hash, PublicKey key) {
+        return key.verify(hash, signature);
+    }
+
+    public byte[] getSignature() {
+        return signature;
+    }
+}

--- a/api/src/main/java/org/hyperledger/transaction/Transaction.java
+++ b/api/src/main/java/org/hyperledger/transaction/Transaction.java
@@ -14,19 +14,34 @@
 package org.hyperledger.transaction;
 
 import org.hyperledger.common.Hash;
+import org.hyperledger.common.PublicKey;
 import org.hyperledger.merkletree.MerkleTreeNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-/**
- * A transaction in the ledger.
- * A transaction reallocates inputs to outputs. Inputs are outputs of previous transactions.
- */
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
+
 public class Transaction implements MerkleTreeNode {
-    private TID ID;
-    private byte [] payload;
+    private static final Logger log = LoggerFactory.getLogger(Transaction.class);
 
-    public Transaction(byte [] payload) {
-        this.ID = new TID(Hash.of(payload));
+    private final TID ID;
+    private final byte[] payload;
+    private final List<Endorser> endorsers;
+
+    public Transaction(byte[] payload, List<Endorser> endorsers) {
         this.payload = payload;
+        this.endorsers = endorsers;
+        this.ID = new TID(Hash.of(toByteArray()));
+    }
+
+    public Transaction(Transaction t) {
+        payload = t.payload;
+        endorsers = t.endorsers;
+        ID = t.ID;
     }
 
     /**
@@ -38,11 +53,6 @@ public class Transaction implements MerkleTreeNode {
     }
 
 
-    /**
-     * get the Transaction ID
-     *
-     * @return id
-     */
     public TID getID() {
         return ID;
     }
@@ -50,4 +60,53 @@ public class Transaction implements MerkleTreeNode {
     public byte[] getPayload() {
         return payload;
     }
+
+    public List<Endorser> getEndorsers() {
+        return endorsers;
+    }
+
+    /**
+     * Verifies if the endorser signed the transaction with the private pair
+     * of the provided public key.
+     */
+    public boolean verify(Endorser endorser, PublicKey key) {
+        byte[] hash = Hash.of(payload).toByteArray();
+        return endorser.verify(hash, key);
+    }
+
+    public byte[] toByteArray() {
+        try {
+            return toByteArray(payload, endorsers);
+        } catch (IOException e) {
+            log.error("Failed to serialize transaction {}: {}", ID, e.getMessage());
+            return new byte[0];
+        }
+    }
+
+    public static byte[] toByteArray(byte[] payload, List<Endorser> endorsers) throws IOException {
+        List<ByteBuffer> endorserBytes = endorsers.stream()
+                .map(endorser -> ByteBuffer.wrap(endorser.getSignature()))
+                .collect(toList());
+
+        SerializedTransaction t = SerializedTransaction.newBuilder()
+                .setPayload(ByteBuffer.wrap(payload))
+                .setEndorsers(endorserBytes)
+                .build();
+
+        return AvroSerializer.serialize(t);
+    }
+
+    public static Transaction fromByteArray(byte[] array) throws IOException {
+        SerializedTransaction t = AvroSerializer.deserialize(array, SerializedTransaction.getClassSchema());
+
+        List<Endorser> endorsers = t.getEndorsers().stream()
+                .map(endorser -> new Endorser(endorser.array()))
+                .collect(toList());
+
+        return new TransactionBuilder()
+                .payload(t.getPayload().array())
+                .endorsers(endorsers)
+                .build();
+    }
+
 }

--- a/api/src/main/java/org/hyperledger/transaction/TransactionBuilder.java
+++ b/api/src/main/java/org/hyperledger/transaction/TransactionBuilder.java
@@ -1,0 +1,52 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.hyperledger.transaction;
+
+import org.hyperledger.common.Hash;
+import org.hyperledger.common.PrivateKey;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TransactionBuilder {
+
+    private byte[] payload = new byte[0];
+    private List<Endorser> endorsers = new ArrayList<>();
+    private List<PrivateKey> endorserKeys = new ArrayList<>();
+
+    public TransactionBuilder payload(byte[] payload) {
+        this.payload = payload;
+        return this;
+    }
+
+    public TransactionBuilder endorsers(List<Endorser> endorsers) {
+        this.endorsers.addAll(endorsers);
+        return this;
+    }
+
+    public TransactionBuilder endorse(PrivateKey key) {
+        endorserKeys.add(key);
+        return this;
+    }
+
+    public Transaction build() {
+        for (PrivateKey key : endorserKeys) {
+            Endorser endorser = Endorser.create(Hash.of(payload).toByteArray(), key);
+            endorsers.add(endorser);
+        }
+        return new Transaction(payload, endorsers);
+    }
+
+}

--- a/api/src/test/java/org/hyperledger/api/connector/GRPCClientTest.java
+++ b/api/src/test/java/org/hyperledger/api/connector/GRPCClientTest.java
@@ -17,6 +17,7 @@ import org.hyperledger.api.HLAPIException;
 import org.hyperledger.api.HLAPITransaction;
 import org.hyperledger.transaction.TID;
 import org.hyperledger.transaction.Transaction;
+import org.hyperledger.transaction.TransactionBuilder;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -52,7 +53,7 @@ public class GRPCClientTest {
 
     @Test
     public void sendTransaction() throws HLAPIException, InterruptedException {
-        Transaction tx = new Transaction(new byte[100]);
+        Transaction tx = new TransactionBuilder().payload(new byte[100]).build();
 
         int originalHeight = client.getChainHeight();
         client.sendTransaction(tx);

--- a/api/src/test/java/org/hyperledger/transaction/TransactionTest.java
+++ b/api/src/test/java/org/hyperledger/transaction/TransactionTest.java
@@ -1,0 +1,76 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.hyperledger.transaction;
+
+import org.hyperledger.common.BouncyCastleCrypto;
+import org.hyperledger.common.Cryptography;
+import org.hyperledger.common.PrivateKey;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Random;
+
+import static org.junit.Assert.*;
+
+public class TransactionTest {
+
+    private Cryptography crypto = new BouncyCastleCrypto();
+
+    @Test
+    public void serialization() throws IOException {
+        Transaction original = new TransactionBuilder()
+                .payload(randomBytes(100))
+                .endorsers(Collections.singletonList(new Endorser(randomBytes(32))))
+                .build();
+
+        byte[] serialized = original.toByteArray();
+        Transaction result = Transaction.fromByteArray(serialized);
+
+        assertEquals(original.getID(), result.getID());
+    }
+
+    private byte[] randomBytes(int length) {
+        byte[] payload = new byte[length];
+        new Random().nextBytes(payload);
+        return payload;
+    }
+
+    @Test
+    public void signatureValidationSucceeds() {
+        PrivateKey key = PrivateKey.createNew(crypto);
+
+        Transaction t = new TransactionBuilder()
+                .payload(randomBytes(100))
+                .endorse(key)
+                .build();
+
+        assertTrue(t.verify(t.getEndorsers().get(0), key.getPublic()));
+    }
+
+    @Test
+    public void signatureValidationFails() {
+        PrivateKey key1 = PrivateKey.createNew(crypto);
+        PrivateKey key2 = PrivateKey.createNew(crypto);
+
+        Transaction t = new TransactionBuilder()
+                .payload(randomBytes(100))
+                .endorse(key1)
+                .build();
+
+        assertFalse(t.verify(t.getEndorsers().get(0), key2.getPublic()));
+    }
+
+}

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -29,7 +29,6 @@
     </parent>
 
     <modules>
-        <module>jmsclient</module>
         <module>chainexplorer</module>
     </modules>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,8 @@
         <slf4j.version>1.7.7</slf4j.version>
         <logback.version>1.1.2</logback.version>
         <junit.version>4.12</junit.version>
+        <avro.version>1.8.1</avro.version>
+        <bouncycastle.version>1.52</bouncycastle.version>
     </properties>
 
     <dependencyManagement>
@@ -83,6 +85,16 @@
                 <groupId>org.slf4j</groupId>
                 <artifactId>jul-to-slf4j</artifactId>
                 <version>${slf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.avro</groupId>
+                <artifactId>avro</artifactId>
+                <version>${avro.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcprov-jdk15on</artifactId>
+                <version>${bouncycastle.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
## Description
This PR introduces a format for the transactions, and a serialization for them. The transactions can have a payload, and some endorsers, which signs the transaction. It uses Avro for serialization, the important thing here is that we need a reliable order of fields, and binary representation. It introduces an interface for cryptography, where we can plug in implementations that fulfil our needs.

## How Has This Been Tested?
Unit tests for transaction serialization and signing are added.

## Checklist:
- [ x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [ x] Either no new documentation is required by this change, OR I added new documentation
- [ x] Either no new tests are required by this change, OR I added new tests

Signed-off-by: Zsolt Szilagyi <zsolt@digitalasset.com>

