### PR TITLE
Derived uuid

### DIFF
--- a/api/src/main/java/org/hyperledger/api/connector/GRPCClient.java
+++ b/api/src/main/java/org/hyperledger/api/connector/GRPCClient.java
@@ -23,7 +23,6 @@ import io.grpc.netty.NettyChannelBuilder;
 import org.hyperledger.api.*;
 import org.hyperledger.block.BID;
 import org.hyperledger.block.Block;
-import org.hyperledger.common.ByteUtils;
 import org.hyperledger.transaction.TID;
 import org.hyperledger.transaction.Transaction;
 import org.slf4j.Logger;
@@ -67,13 +66,17 @@ public class GRPCClient implements HLAPI {
     }
 
     public void invoke(String chaincodeName, byte[] transaction) {
+        invoke(chaincodeName, "execute", transaction);
+    }
+
+    public void invoke(String chaincodeName, String functionName, byte[] transaction) {
         String encodedTransaction = Base64.getEncoder().encodeToString(transaction);
 
         ChaincodeID.Builder chaincodeId = ChaincodeID.newBuilder();
         chaincodeId.setName(chaincodeName);
 
         ChaincodeInput.Builder chaincodeInput = ChaincodeInput.newBuilder();
-        chaincodeInput.setFunction("execute");
+        chaincodeInput.setFunction(functionName);
         chaincodeInput.addArgs(encodedTransaction);
 
         ChaincodeSpec.Builder chaincodeSpec = ChaincodeSpec.newBuilder();
@@ -81,7 +84,7 @@ public class GRPCClient implements HLAPI {
         chaincodeSpec.setCtorMsg(chaincodeInput);
 
         ChaincodeInvocationSpec.Builder chaincodeInvocationSpec = ChaincodeInvocationSpec.newBuilder();
-        chaincodeInvocationSpec.setChaincodeSpec(chaincodeSpec);
+        chaincodeInvocationSpec.setChaincodeSpec(chaincodeSpec).setUuidGenerationAlg("sha256base64");
 
         dbs.invoke(chaincodeInvocationSpec.build());
     }
@@ -154,8 +157,7 @@ public class GRPCClient implements HLAPI {
 
     @Override
     public HLAPITransaction getTransaction(TID hash) throws HLAPIException {
-        String hexedHash = ByteUtils.toHex(hash.toByteArray());
-        ByteString result = query("getTran", Collections.singletonList(hexedHash));
+        ByteString result = query("getTran", Collections.singletonList(hash.toUuidString()));
         byte[] resultStr = result.toByteArray();
         if (resultStr.length == 0) return null;
         try {
@@ -176,12 +178,12 @@ public class GRPCClient implements HLAPI {
 
     @Override
     public void registerRejectListener(RejectListener rejectListener) throws HLAPIException {
-        throw new UnsupportedOperationException();
+        observer.subscribeToRejections(rejectListener);
     }
 
     @Override
     public void removeRejectListener(RejectListener rejectListener) {
-        throw new UnsupportedOperationException();
+        observer.unsubscribeFromRejections(rejectListener);
     }
 
 
@@ -192,22 +194,22 @@ public class GRPCClient implements HLAPI {
 
     @Override
     public void registerTransactionListener(TransactionListener listener) throws HLAPIException {
-        observer.subscribe(listener);
+        observer.subscribeToTransactions(listener);
     }
 
     @Override
     public void removeTransactionListener(TransactionListener listener) {
-        observer.unsubscribe(listener);
+        observer.unsubscribeFromTransactions(listener);
     }
 
     @Override
     public void registerTrunkListener(TrunkListener listener) throws HLAPIException {
-        throw new UnsupportedOperationException();
+        observer.subscribeToBlocks(listener);
     }
 
     @Override
     public void removeTrunkListener(TrunkListener listener) {
-        throw new UnsupportedOperationException();
+        observer.unsubscribeFromBlocks(listener);
     }
 
     @Override

--- a/api/src/main/java/org/hyperledger/api/connector/GRPCClient.java
+++ b/api/src/main/java/org/hyperledger/api/connector/GRPCClient.java
@@ -84,7 +84,7 @@ public class GRPCClient implements HLAPI {
         chaincodeSpec.setCtorMsg(chaincodeInput);
 
         ChaincodeInvocationSpec.Builder chaincodeInvocationSpec = ChaincodeInvocationSpec.newBuilder();
-        chaincodeInvocationSpec.setChaincodeSpec(chaincodeSpec).setUuidGenerationAlg("sha256base64");
+        chaincodeInvocationSpec.setChaincodeSpec(chaincodeSpec).setIdGenerationAlg("sha256base64");
 
         dbs.invoke(chaincodeInvocationSpec.build());
     }

--- a/api/src/main/java/org/hyperledger/api/connector/GRPCObserver.java
+++ b/api/src/main/java/org/hyperledger/api/connector/GRPCObserver.java
@@ -17,29 +17,30 @@
 package org.hyperledger.api.connector;
 
 import com.google.protobuf.ByteString;
-import com.google.protobuf.InvalidProtocolBufferException;
-
 import io.grpc.Channel;
 import io.grpc.stub.StreamObserver;
-import org.hyperledger.api.HLAPIException;
-import org.hyperledger.api.HLAPITransaction;
-import org.hyperledger.api.TransactionListener;
+import org.hyperledger.api.*;
 import org.hyperledger.block.BID;
 import org.hyperledger.transaction.Transaction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import protos.Chaincode;
 import protos.EventsGrpc;
 import protos.EventsOuterClass;
-import protos.Fabric.Block;
+import protos.Fabric.TransactionResult;
 
 import javax.xml.bind.DatatypeConverter;
 import java.io.IOException;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
+import java.util.stream.Collectors;
 
 public class GRPCObserver {
+    private static final Logger log = LoggerFactory.getLogger(GRPCObserver.class);
+
     private EventsGrpc.EventsStub es;
-    private Set<TransactionListener> listeners = new HashSet<>();
+    private Set<TransactionListener> txListeners = new HashSet<>();
+    private Set<TrunkListener> trunkListeners = new HashSet<>();
+    private Set<RejectListener> rejectionListeners = new HashSet<>();
 
     public GRPCObserver(Channel eventsChannel) {
         es = EventsGrpc.newStub(eventsChannel);
@@ -49,28 +50,71 @@ public class GRPCObserver {
         StreamObserver<EventsOuterClass.Event> receiver = new StreamObserver<EventsOuterClass.Event>() {
             @Override
             public void onNext(EventsOuterClass.Event openchainEvent) {
-                listeners.forEach((listener) -> {
-                    try {
-                        if (openchainEvent.getEventCase() == EventsOuterClass.Event.EventCase.BLOCK) {
-                            Block block = openchainEvent.getBlock();
-                            processAll(listener, block.getTransactionsList());
-                        }
-                    } catch (HLAPIException | IOException e) {
-                        e.printStackTrace();
-                    }
-                });
+                if (openchainEvent.getEventCase() == EventsOuterClass.Event.EventCase.BLOCK) {
+                    List<HLAPITransaction> transactionsList = convertToHLAPITxList(openchainEvent.getBlock().getTransactionsList());
+                    HLAPIBlock block = new HLAPIBlock.Builder().transactions(transactionsList).build();
+                    Map<String, TransactionResult> results = openchainEvent.getBlock().getNonHashData()
+                            .getTransactionResultsList().stream()
+                            .collect(Collectors.toMap(TransactionResult::getUuid, item -> item));
+
+                    serveTransactionListeners(transactionsList, results);
+                    serveRejectionListeners(transactionsList, results);
+                    serveTrunkListeners(block);
+                }
                 System.out.println("new event: " + openchainEvent.toString());
             }
 
-            private void processAll(TransactionListener listener, List<protos.Fabric.Transaction> transactionsList) throws HLAPIException, IOException {
-                for(protos.Fabric.Transaction tx : transactionsList) {
-                    ByteString invocationSpecBytes = tx.getPayload();
-                    Chaincode.ChaincodeInvocationSpec invocationSpec = Chaincode.ChaincodeInvocationSpec.parseFrom(invocationSpecBytes);
-                    String transactionString = invocationSpec.getChaincodeSpec().getCtorMsg().getArgs(0);
-                    byte[] transactionBytes = DatatypeConverter.parseBase64Binary(transactionString);
-                    HLAPITransaction hlapitx = new HLAPITransaction(Transaction.fromByteArray(transactionBytes), BID.INVALID);
-                    listener.process(hlapitx);
+            private void serveTransactionListeners(List<HLAPITransaction> transactionsList, Map<String, TransactionResult> results) {
+                for (HLAPITransaction tx : transactionsList) {
+                    txListeners.forEach((txListener) -> {
+                        try {
+                            TransactionResult result = results.get(tx.getID().toUuidString());
+                            if (result.getErrorCode() == 0) {
+                                txListener.process(tx);
+                            }
+                        } catch (HLAPIException e) {
+                            e.printStackTrace();
+                        }
+                    });
                 }
+            }
+
+            private void serveRejectionListeners(List<HLAPITransaction> transactionsList, Map<String, TransactionResult> results) {
+                for (HLAPITransaction tx : transactionsList) {
+                    rejectionListeners.forEach((rjListener) -> {
+                        TransactionResult result = results.get(tx.getID().toUuidString());
+                        if (result.getErrorCode() != 0) {
+                            rjListener.rejected("invoke", tx.getID(), result.getError(), result.getErrorCode());
+                        }
+                    });
+                }
+            }
+
+            private void serveTrunkListeners(HLAPIBlock block) {
+                List<HLAPIBlock> blocks = new ArrayList<>(1);
+                blocks.add(block);
+                trunkListeners.forEach((blockListener) -> {
+                    blockListener.trunkUpdate(blocks);
+                });
+            }
+
+            private List<HLAPITransaction> convertToHLAPITxList(List<protos.Fabric.Transaction> transactionsList) {
+                List<HLAPITransaction> result = new ArrayList<>(transactionsList.size());
+                for (protos.Fabric.Transaction tx : transactionsList) {
+                    ByteString invocationSpecBytes = tx.getPayload();
+                    Chaincode.ChaincodeInvocationSpec invocationSpec;
+                    try {
+                        invocationSpec = Chaincode.ChaincodeInvocationSpec.parseFrom(invocationSpecBytes);
+                        String transactionString = invocationSpec.getChaincodeSpec().getCtorMsg().getArgs(0);
+                        byte[] transactionBytes = DatatypeConverter.parseBase64Binary(transactionString);
+                        HLAPITransaction hlapitx = new HLAPITransaction(Transaction.fromByteArray(transactionBytes), BID.INVALID);
+                        result.add(hlapitx);
+                    } catch (IOException e) {
+                        log.error("Error when processing transaction: {}", e.getMessage());
+                    }
+
+                }
+                return result;
             }
 
             @Override
@@ -102,11 +146,27 @@ public class GRPCObserver {
         sender.onNext(registerEvent);
     }
 
-    public void subscribe(TransactionListener l) {
-        listeners.add(l);
+    public void subscribeToTransactions(TransactionListener l) {
+        txListeners.add(l);
     }
 
-    public void unsubscribe(TransactionListener l) {
-        listeners.remove(l);
+    public void unsubscribeFromTransactions(TransactionListener l) {
+        txListeners.remove(l);
+    }
+
+    public void subscribeToBlocks(TrunkListener l) {
+        trunkListeners.add(l);
+    }
+
+    public void unsubscribeFromBlocks(TrunkListener l) {
+        trunkListeners.remove(l);
+    }
+
+    public void subscribeToRejections(RejectListener l) {
+        rejectionListeners.add(l);
+    }
+
+    public void unsubscribeFromRejections(RejectListener l) {
+        rejectionListeners.remove(l);
     }
 }

--- a/api/src/main/java/org/hyperledger/api/connector/GRPCObserver.java
+++ b/api/src/main/java/org/hyperledger/api/connector/GRPCObserver.java
@@ -131,8 +131,7 @@ public class GRPCObserver {
         StreamObserver<EventsOuterClass.Event> sender = es.chat(receiver);
 
         EventsOuterClass.Interest interest = EventsOuterClass.Interest.newBuilder()
-                .setEventType("block")
-                .setResponseType(EventsOuterClass.Interest.ResponseType.PROTOBUF)
+                .setEventType(EventsOuterClass.EventType.BLOCK)
                 .build();
 
         EventsOuterClass.Register register = EventsOuterClass.Register.newBuilder()

--- a/api/src/main/java/org/hyperledger/common/Hash.java
+++ b/api/src/main/java/org/hyperledger/common/Hash.java
@@ -24,6 +24,8 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 
+import org.apache.commons.codec.binary.Hex;
+
 /**
  * A Hash identifies objects, that is blocks and transactions, in the ledger.
  * Technically it is a double SHA256 digest of the object's content.
@@ -125,43 +127,28 @@ public class Hash {
     }
 
     /**
-     * return SHA256 hash of data
-     *
-     * @param data arbitary data
-     * @return SHA256(data)
-     */
-    public static byte[] sha256(byte[] data) {
-        try {
-            MessageDigest a = MessageDigest.getInstance("SHA-256");
-            return a.digest(data);
-        } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    /**
-     * Double SHA256 hash of arbitrary data
+     * SHA256 hash of arbitrary data
      *
      * @param data   arbitary data
      * @param offset start hashing at this offset (0 starts)
      * @param len    hash len number of bytes
-     * @return SHA256(SHA256(data))
+     * @return SHA256(data)
      */
     public static byte[] hash(byte[] data, int offset, int len) {
         try {
             MessageDigest a = MessageDigest.getInstance("SHA-256");
             a.update(data, offset, len);
-            return a.digest(a.digest());
+            return a.digest();
         } catch (NoSuchAlgorithmException e) {
             throw new RuntimeException(e);
         }
     }
 
     /**
-     * Double SHA256 hash of arbitrary data
+     * SHA256 hash of arbitrary data
      *
      * @param data arbitrary data
-     * @return SHA256(SHA256(data))
+     * @return SHA256(data)
      */
     public static byte[] hash(byte[] data) {
         return hash(data, 0, data.length);
@@ -175,6 +162,18 @@ public class Hash {
      */
     public static Hash of(byte[] data) {
         return new Hash(hash(data, 0, data.length));
+    }
+
+    /**
+     * UUID created from the first 128 bits of SHA256
+     *
+     * @return String
+     */
+    public String toUuidString() {
+            String result = String.join("-", contentAsHex(0, 4), contentAsHex(4, 6),
+                                             contentAsHex(6, 8), contentAsHex(8, 10),
+                                             contentAsHex(10, 16));
+            return result.toLowerCase();
     }
 
     /**
@@ -216,5 +215,9 @@ public class Hash {
         if (!Arrays.equals(bytes, hash.bytes)) return false;
 
         return true;
+    }
+
+    private String contentAsHex(int i, int j) {
+        return ByteUtils.toHex((Arrays.copyOfRange(bytes, i, j)));
     }
 }

--- a/api/src/main/java/org/hyperledger/transaction/Transaction.java
+++ b/api/src/main/java/org/hyperledger/transaction/Transaction.java
@@ -76,6 +76,21 @@ public class Transaction implements MerkleTreeNode {
         return endorser.verify(hash, key);
     }
 
+    @Override
+    public int hashCode() {
+        return ID.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof Transaction) {
+            Transaction other = (Transaction) obj;
+            return ID.equals(other.ID);
+        } else {
+            return false;
+        }
+    }
+
     public byte[] toByteArray() {
         try {
             return toByteArray(payload, endorsers);

--- a/api/src/main/proto/chaincode.proto
+++ b/api/src/main/proto/chaincode.proto
@@ -94,9 +94,13 @@ message ChaincodeInvocationSpec {
 
     ChaincodeSpec chaincodeSpec = 1;
     //ChaincodeInput message = 2;
-
+    string userGivenID = 2;
 }
 
+// This structure contain transaction data that we send to the chaincode
+// container shim and allow the chaincode to access through the shim interface.
+// TODO: Consider remove this message and just pass the transaction object
+// to the shim and/or allow the chaincode to query transactions.
 message ChaincodeSecurityContext {
     bytes callerCert = 1;
     bytes callerSign = 2;
@@ -104,6 +108,7 @@ message ChaincodeSecurityContext {
     bytes binding = 4;
     bytes metadata = 5;
     bytes parentMetadata = 6;
+    google.protobuf.Timestamp txTimestamp = 7; // transaction timestamp
 }
 
 message ChaincodeMessage {

--- a/api/src/main/proto/chaincode.proto
+++ b/api/src/main/proto/chaincode.proto
@@ -94,7 +94,14 @@ message ChaincodeInvocationSpec {
 
     ChaincodeSpec chaincodeSpec = 1;
     //ChaincodeInput message = 2;
-    string userGivenID = 2;
+    // This field can contain a user-specified UUID generation algorithm
+    // If supplied, this will be used to generate a UUID
+    // If not supplied (left empty), a random UUID will be generated
+    // The algorithm consists of two parts:
+    //  1, a hash function
+    //  2, a decoding used to decode user (string) input to bytes
+    // Currently, SHA256 with BASE64 is supported (e.g. uuidGenerationAlg='sha256base64')
+    string uuidGenerationAlg = 2;
 }
 
 // This structure contain transaction data that we send to the chaincode

--- a/api/src/main/proto/chaincode.proto
+++ b/api/src/main/proto/chaincode.proto
@@ -18,6 +18,7 @@ syntax = "proto3";
 
 package protos;
 
+import "chaincodeevent.proto";
 import "google/protobuf/timestamp.proto";
 
 
@@ -70,6 +71,7 @@ message ChaincodeSpec {
     string secureContext = 5;
     ConfidentialityLevel confidentialityLevel = 6;
     bytes metadata = 7;
+    repeated string attributes = 8;
 }
 
 // Specify the deployment of a chaincode.
@@ -93,15 +95,14 @@ message ChaincodeDeploymentSpec {
 message ChaincodeInvocationSpec {
 
     ChaincodeSpec chaincodeSpec = 1;
-    //ChaincodeInput message = 2;
-    // This field can contain a user-specified UUID generation algorithm
-    // If supplied, this will be used to generate a UUID
+    // This field can contain a user-specified ID generation algorithm
+    // If supplied, this will be used to generate a ID
     // If not supplied (left empty), a random UUID will be generated
     // The algorithm consists of two parts:
     //  1, a hash function
     //  2, a decoding used to decode user (string) input to bytes
-    // Currently, SHA256 with BASE64 is supported (e.g. uuidGenerationAlg='sha256base64')
-    string uuidGenerationAlg = 2;
+    // Currently, SHA256 with BASE64 is supported (e.g. idGenerationAlg='sha256base64')
+    string idGenerationAlg = 2;
 }
 
 // This structure contain transaction data that we send to the chaincode
@@ -141,6 +142,7 @@ message ChaincodeMessage {
         RANGE_QUERY_STATE = 17;
         RANGE_QUERY_STATE_NEXT = 18;
         RANGE_QUERY_STATE_CLOSE = 19;
+        KEEPALIVE = 20;
     }
 
     Type type = 1;
@@ -148,6 +150,11 @@ message ChaincodeMessage {
     bytes payload = 3;
     string uuid = 4;
     ChaincodeSecurityContext securityContext = 5;
+
+    //event emmited by chaincode. Used only with Init or Invoke.
+    // This event is then stored (currently)
+    //with Block.NonHashData.TransactionResult
+    ChaincodeEvent chaincodeEvent = 6;
 }
 
 message PutStateInfo {

--- a/api/src/main/proto/chaincodeevent.proto
+++ b/api/src/main/proto/chaincodeevent.proto
@@ -1,0 +1,26 @@
+/*
+Copyright IBM Corp. 2016 All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		 http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+syntax = "proto3";
+package protos;
+
+//Chaincode is used for events and registrations that are specific to chaincode
+//string type - "chaincode"
+message ChaincodeEvent {
+      string chaincodeID = 1;
+      string txID = 2;
+      string eventName = 3;
+      bytes payload = 4;
+}

--- a/api/src/main/proto/devops.proto
+++ b/api/src/main/proto/devops.proto
@@ -39,6 +39,21 @@ service Devops {
     // Invoke chaincode.
     rpc Query(ChaincodeInvocationSpec) returns (Response) {}
 
+    // Request a TransactionResult.  The Response.Msg will contain the TransactionResult if successfully found the transaction in the chain.
+    rpc GetTransactionResult(TransactionRequest) returns (Response) {}
+
+    // Retrieve a TCert.
+    rpc EXP_GetApplicationTCert(Secret) returns (Response) {}
+
+    // Prepare for performing a TX, which will return a binding that can later be used to sign and then execute a transaction.
+    rpc EXP_PrepareForTx(Secret) returns (Response) {}
+
+    // Prepare for performing a TX, which will return a binding that can later be used to sign and then execute a transaction.
+    rpc EXP_ProduceSigma(SigmaInput) returns (Response) {}
+
+    // Execute a transaction with a specific binding
+    rpc EXP_ExecuteWithBinding(ExecuteWithBinding) returns (Response) {}
+
 }
 
 
@@ -48,6 +63,24 @@ message Secret {
     string enrollId = 1;
     string enrollSecret = 2;
 }
+
+message SigmaInput {
+    Secret secret = 1;
+    bytes appTCert = 2;
+    bytes data = 3;
+}
+
+message ExecuteWithBinding {
+    ChaincodeInvocationSpec chaincodeInvocationSpec = 1;
+    bytes binding = 2;    
+}
+
+message SigmaOutput {
+    bytes tcert = 1;
+    bytes sigma = 2;
+    bytes asn1Encoding = 3;
+}
+
 
 message BuildResult {
 
@@ -60,4 +93,8 @@ message BuildResult {
     StatusCode status = 1;
     string msg = 2;
     ChaincodeDeploymentSpec deploymentSpec = 3;
+}
+
+message TransactionRequest {
+    string transactionUuid = 1;
 }

--- a/api/src/main/proto/events.proto
+++ b/api/src/main/proto/events.proto
@@ -16,26 +16,37 @@ limitations under the License.
 
 syntax = "proto3";
 
+import "chaincodeevent.proto";
 import "fabric.proto";
 
 package protos;
 
+
 //----Event objects----
 
-message Interest {
-    enum ResponseType {
-        //don't send events (used to cancel interest)
-        DONTSEND = 0;
-        //send protobuf objects
-        PROTOBUF = 1;
-        //marshall into JSON byte array
-        JSON = 2;
-    }
-    string eventType = 1;
-    ResponseType responseType = 2;
+enum EventType {
+        REGISTER = 0;
+        BLOCK = 1;
+	CHAINCODE = 2;
 }
 
+//ChaincodeReg is used for registering chaincode Interests
+//when EventType is CHAINCODE
+message ChaincodeReg {
+    string chaincodeID = 1;
+    string eventName = 2;
+}
 
+message Interest {
+    EventType eventType = 1;
+    //Ideally we should just have the following oneof for different
+    //Reg types and get rid of EventType. But this is an API change
+    //Additional Reg types may add messages specific to their type
+    //to the oneof.
+    oneof RegInfo {
+        ChaincodeReg chaincodeRegInfo = 2;
+    }
+}
 
 //---------- consumer events ---------
 //Register is sent by consumers for registering events
@@ -44,26 +55,19 @@ message Register {
     repeated Interest events = 1;
 }
 
-//---------- producer events ---------
-//Generic is used for encoding payload as JSON or raw bytes
-//string type - "generic"
-message Generic {
-    string eventType = 1;
-    bytes payload = 2;
-}
-
 //Event is used by
 //  - consumers (adapters) to send Register
 //  - producer to advertise supported types and events
 message Event {
     //TODO need timestamp
+
     oneof Event {
         //consumer events
         Register register = 1;
 
         //producer events
         Block block = 2;
-        Generic generic = 3;
+        ChaincodeEvent chaincodeEvent = 3;
     }
 }
 

--- a/api/src/main/proto/fabric.proto
+++ b/api/src/main/proto/fabric.proto
@@ -16,6 +16,7 @@ limitations under the License.
 syntax = "proto3";
 package protos;
 import "chaincode.proto";
+import "chaincodeevent.proto";
 import "google/protobuf/timestamp.proto";
 
 
@@ -64,11 +65,13 @@ message TransactionBlock {
 // result - The return value of the transaction.
 // errorCode - An error code. 5xx will be logged as a failure in the dashboard.
 // error - An error string for logging an issue.
+// chaincodeEvent - any event emitted by a transaction
 message TransactionResult {
   string uuid = 1;
   bytes result = 2;
   uint32 errorCode = 3;
   string error = 4;
+  ChaincodeEvent chaincodeEvent = 5;
 }
 
 // Block carries The data that describes a block in the blockchain.
@@ -201,8 +204,9 @@ message BlockState {
 // example, if start=3 and end=5, the order of blocks will be 3, 4, 5.
 // If start=5 and end=3, the order will be 5, 4, 3.
 message SyncBlockRange {
-    uint64 start = 1;
-    uint64 end = 2;
+    uint64 correlationId = 1;
+    uint64 start = 2;
+    uint64 end = 3;
 }
 // SyncBlocks is the payload of Message.SYNC_BLOCKS, where the range
 // indicates the blocks responded to the request SYNC_GET_BLOCKS

--- a/api/src/test/java/org/hyperledger/api/connector/GRPCClientTest.java
+++ b/api/src/test/java/org/hyperledger/api/connector/GRPCClientTest.java
@@ -15,16 +15,21 @@
  */
 package org.hyperledger.api.connector;
 
-import org.hyperledger.api.HLAPIException;
-import org.hyperledger.api.HLAPITransaction;
-import org.hyperledger.api.TransactionListener;
+import io.grpc.StatusRuntimeException;
+import org.hamcrest.CoreMatchers;
+import org.hyperledger.api.*;
+import org.hyperledger.common.Hash;
 import org.hyperledger.transaction.TID;
 import org.hyperledger.transaction.Transaction;
 import org.hyperledger.transaction.TransactionBuilder;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.List;
 
 import static org.junit.Assert.*;
 
@@ -47,10 +52,14 @@ public class GRPCClientTest {
         assertTrue(height > 0);
     }
 
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
     @Test
     public void getNonExistingTransaction() throws HLAPIException {
-        HLAPITransaction res = client.getTransaction(TID.INVALID);
-        assertTrue(res == null);
+        thrown.expect(StatusRuntimeException.class);
+        thrown.expectMessage(CoreMatchers.containsString("ledger: resource not found"));
+        client.getTransaction(TID.INVALID);
     }
 
     @Test
@@ -61,7 +70,6 @@ public class GRPCClientTest {
         client.sendTransaction(tx);
 
         Thread.sleep(1500);
-
         HLAPITransaction res = client.getTransaction(tx.getID());
         assertEquals(tx.getID(), res.getID());
         assertArrayEquals(tx.getPayload(), res.getPayload());
@@ -73,6 +81,7 @@ public class GRPCClientTest {
     public void transactionListener() throws HLAPIException, InterruptedException {
         Transaction tx1 = new TransactionBuilder().payload(new byte[100]).build();
         Transaction tx2 = new TransactionBuilder().payload(new byte[90]).build();
+        Transaction tx3 = new TransactionBuilder().payload(new byte[95]).build();
         class TestListener implements TransactionListener {
             private byte processedTxCount = 0;
 
@@ -86,21 +95,94 @@ public class GRPCClientTest {
                 System.out.println(t.getID().toString());
             }
 
-        };
+        }
         TestListener listener = new TestListener();
         client.registerTransactionListener(listener);
 
         client.sendTransaction(tx1);
         client.sendTransaction(tx2);
+        client.invoke(client.chaincodeName, "some-fake-function-name", tx3.toByteArray());
 
         byte expectedTxCount = 2;
         byte counter = 3;
-        while(counter != 0 && expectedTxCount != listener.getProcessedTxCount())
-        {
-          Thread.sleep(1000);
-          counter--;
+        while (counter != 0 && expectedTxCount != listener.getProcessedTxCount()) {
+            Thread.sleep(1000);
+            counter--;
         }
         client.removeTransactionListener(listener);
+        assertEquals(expectedTxCount, listener.getProcessedTxCount());
+    }
+
+    @Test
+    public void trunkListener() throws HLAPIException, InterruptedException {
+        Transaction tx1 = new TransactionBuilder().payload(new byte[100]).build();
+        Transaction tx2 = new TransactionBuilder().payload(new byte[90]).build();
+        class TestListener implements TrunkListener {
+            private byte processedBlockCount = 0;
+            private byte processedTxCount = 0;
+
+            public byte getProcessedTxCount() {
+                return processedTxCount;
+            }
+
+            public byte getProcessedBlockCount() {
+                return processedBlockCount;
+            }
+
+            @Override
+            public void trunkUpdate(List<HLAPIBlock> added) {
+                processedBlockCount += added.size();
+                for (HLAPIBlock b : added) {
+                    processedTxCount += b.getTransactions().size();
+                }
+            }
+        }
+        TestListener listener = new TestListener();
+        client.registerTrunkListener(listener);
+        client.invoke(client.chaincodeName, "some-fake-function-name", tx1.toByteArray());
+        client.sendTransaction(tx2);
+
+        byte expectedBlockCount = 1;
+        byte expectedTxCount = 2;
+        byte counter = 3;
+        while (counter != 0 && expectedTxCount != listener.getProcessedTxCount()) {
+            Thread.sleep(1000);
+            counter--;
+        }
+        client.removeTrunkListener(listener);
+        assertEquals(expectedBlockCount, listener.getProcessedBlockCount());
+        assertEquals(expectedTxCount, listener.getProcessedTxCount());
+    }
+
+    @Test
+    public void rejectListener() throws HLAPIException, InterruptedException {
+        Transaction tx1 = new TransactionBuilder().payload(new byte[100]).build();
+        Transaction tx2 = new TransactionBuilder().payload(new byte[90]).build();
+        class TestListener implements RejectListener {
+            private byte processedRejectionCount = 0;
+
+            public byte getProcessedTxCount() {
+                return processedRejectionCount;
+            }
+
+            @Override
+            public void rejected(String command, Hash hash, String reason, int rejectionCode) {
+                processedRejectionCount++;
+            }
+        }
+        TestListener listener = new TestListener();
+        client.registerRejectListener(listener);
+
+        client.invoke(client.chaincodeName, "some-fake-function-name", tx1.toByteArray());
+        client.sendTransaction(tx2);
+
+        byte expectedTxCount = 1;
+        byte counter = 3;
+        while (counter != 0 && expectedTxCount != listener.getProcessedTxCount()) {
+            Thread.sleep(1000);
+            counter--;
+        }
+        client.removeRejectListener(listener);
         assertEquals(expectedTxCount, listener.getProcessedTxCount());
     }
 


### PR DESCRIPTION
Fabric now supports derived transaction ID, take this into use.

## Checklist:
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests

Signed-off-by: Zsolt Szilagyi <zsolt@digitalasset.com>
