### PR TITLE
Add inputs and outputs to transactions

### DIFF
--- a/api/src/main/avro/transaction.avsc
+++ b/api/src/main/avro/transaction.avsc
@@ -3,7 +3,8 @@
     "type": "record",
     "name": "SerializedTransaction",
     "fields": [
-        { "name": "payload",    "type": "bytes" },
+        { "name": "inputs",     "type": { "type": "array", "items": "bytes" }},
+        { "name": "outputs",    "type": { "type": "array", "items": "bytes" }},
         { "name": "endorsers",  "type": { "type": "array", "items": "bytes" }}
     ]
 }

--- a/api/src/main/java/org/hyperledger/common/AvroSerializer.java
+++ b/api/src/main/java/org/hyperledger/common/AvroSerializer.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.hyperledger.transaction;
+package org.hyperledger.common;
 
 import org.apache.avro.Schema;
 import org.apache.avro.io.*;
@@ -24,6 +24,11 @@ import org.apache.avro.specific.SpecificRecord;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.function.Function;
+
+import static java.util.stream.Collectors.toList;
 
 public class AvroSerializer {
 
@@ -41,5 +46,17 @@ public class AvroSerializer {
         SpecificDatumReader<T> reader = new SpecificDatumReader<>(schema);
         Decoder decoder = DecoderFactory.get().binaryDecoder(data, null);
         return reader.read(null, decoder);
+    }
+
+    public static <T> List<ByteBuffer> toByteBufferList(List<T> list, Function<T, byte[]> encoder) {
+        return list.stream()
+                .map(item -> ByteBuffer.wrap(encoder.apply(item)))
+                .collect(toList());
+    }
+
+    public static <T> List<T> fromByteBufferList(List<ByteBuffer> list, Function<byte[], T> decoder) {
+        return list.stream()
+                .map(item -> decoder.apply(item.array()))
+                .collect(toList());
     }
 }

--- a/api/src/main/java/org/hyperledger/transaction/TransactionBuilder.java
+++ b/api/src/main/java/org/hyperledger/transaction/TransactionBuilder.java
@@ -24,12 +24,28 @@ import java.util.List;
 
 public class TransactionBuilder {
 
-    private byte[] payload = new byte[0];
-    private List<Endorser> endorsers = new ArrayList<>();
-    private List<PrivateKey> endorserKeys = new ArrayList<>();
+    private final List<TID> inputs = new ArrayList<>();
+    private final List<byte[]> outputs = new ArrayList<>();
+    private final List<Endorser> endorsers = new ArrayList<>();
+    private final List<PrivateKey> endorserKeys = new ArrayList<>();
 
-    public TransactionBuilder payload(byte[] payload) {
-        this.payload = payload;
+    public TransactionBuilder inputs(List<TID> inputs) {
+        this.inputs.addAll(inputs);
+        return this;
+    }
+
+    public TransactionBuilder input(TID input) {
+        inputs.add(input);
+        return this;
+    }
+
+    public TransactionBuilder outputs(List<byte[]> outputs) {
+        this.outputs.addAll(outputs);
+        return this;
+    }
+
+    public TransactionBuilder output(byte[] output) {
+        outputs.add(output);
         return this;
     }
 
@@ -45,10 +61,10 @@ public class TransactionBuilder {
 
     public Transaction build() {
         for (PrivateKey key : endorserKeys) {
-            Endorser endorser = Endorser.create(Hash.of(payload).toByteArray(), key);
+            Endorser endorser = Endorser.create(Hash.of(outputs.get(0)).toByteArray(), key);
             endorsers.add(endorser);
         }
-        return new Transaction(payload, endorsers);
+        return new Transaction(inputs, outputs, endorsers);
     }
 
 }

--- a/api/src/test/java/org/hyperledger/api/connector/GRPCClientTest.java
+++ b/api/src/test/java/org/hyperledger/api/connector/GRPCClientTest.java
@@ -21,7 +21,7 @@ import org.hyperledger.api.*;
 import org.hyperledger.common.Hash;
 import org.hyperledger.transaction.TID;
 import org.hyperledger.transaction.Transaction;
-import org.hyperledger.transaction.TransactionBuilder;
+import org.hyperledger.transaction.TransactionTest;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -31,7 +31,8 @@ import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class GRPCClientTest {
     private static final Logger log = LoggerFactory.getLogger(GRPCClientTest.class);
@@ -64,24 +65,25 @@ public class GRPCClientTest {
 
     @Test
     public void sendTransaction() throws HLAPIException, InterruptedException {
-        Transaction tx = new TransactionBuilder().payload(new byte[100]).build();
+        Transaction tx = TransactionTest.randomTx();
 
         int originalHeight = client.getChainHeight();
         client.sendTransaction(tx);
 
         Thread.sleep(1500);
+
         HLAPITransaction res = client.getTransaction(tx.getID());
-        assertEquals(tx.getID(), res.getID());
-        assertArrayEquals(tx.getPayload(), res.getPayload());
+        assertEquals(tx, res);
+
         int newHeight = client.getChainHeight();
-        assertTrue(newHeight == originalHeight + 1);
+        assertEquals(originalHeight + 1, newHeight);
     }
 
     @Test
     public void transactionListener() throws HLAPIException, InterruptedException {
-        Transaction tx1 = new TransactionBuilder().payload(new byte[100]).build();
-        Transaction tx2 = new TransactionBuilder().payload(new byte[90]).build();
-        Transaction tx3 = new TransactionBuilder().payload(new byte[95]).build();
+        Transaction tx1 = TransactionTest.randomTx();
+        Transaction tx2 = TransactionTest.randomTx();
+        Transaction tx3 = TransactionTest.randomTx();
         class TestListener implements TransactionListener {
             private byte processedTxCount = 0;
 
@@ -115,8 +117,8 @@ public class GRPCClientTest {
 
     @Test
     public void trunkListener() throws HLAPIException, InterruptedException {
-        Transaction tx1 = new TransactionBuilder().payload(new byte[100]).build();
-        Transaction tx2 = new TransactionBuilder().payload(new byte[90]).build();
+        Transaction tx1 = TransactionTest.randomTx();
+        Transaction tx2 = TransactionTest.randomTx();
         class TestListener implements TrunkListener {
             private byte processedBlockCount = 0;
             private byte processedTxCount = 0;
@@ -156,8 +158,8 @@ public class GRPCClientTest {
 
     @Test
     public void rejectListener() throws HLAPIException, InterruptedException {
-        Transaction tx1 = new TransactionBuilder().payload(new byte[100]).build();
-        Transaction tx2 = new TransactionBuilder().payload(new byte[90]).build();
+        Transaction tx1 = TransactionTest.randomTx();
+        Transaction tx2 = TransactionTest.randomTx();
         class TestListener implements RejectListener {
             private byte processedRejectionCount = 0;
 

--- a/api/src/test/java/org/hyperledger/transaction/TransactionTest.java
+++ b/api/src/test/java/org/hyperledger/transaction/TransactionTest.java
@@ -22,31 +22,35 @@ import org.hyperledger.common.PrivateKey;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.Random;
 
 import static org.junit.Assert.*;
 
 public class TransactionTest {
 
-    private Cryptography crypto = new BouncyCastleCrypto();
+    private static final Random random = new Random();
+    private static final Cryptography crypto = new BouncyCastleCrypto();
 
     @Test
     public void serialization() throws IOException {
-        Transaction original = new TransactionBuilder()
-                .payload(randomBytes(100))
-                .endorsers(Collections.singletonList(new Endorser(randomBytes(32))))
-                .build();
-
+        Transaction original = randomTx();
         byte[] serialized = original.toByteArray();
         Transaction result = Transaction.fromByteArray(serialized);
 
-        assertEquals(original.getID(), result.getID());
+        assertEquals(original, result);
     }
 
-    private byte[] randomBytes(int length) {
+    public static Transaction randomTx() {
+        return new TransactionBuilder()
+                .input(new TID(randomBytes(32)))
+                .output(randomBytes(100))
+                .endorse(PrivateKey.createNew(crypto))
+                .build();
+    }
+
+    private static byte[] randomBytes(int length) {
         byte[] payload = new byte[length];
-        new Random().nextBytes(payload);
+        random.nextBytes(payload);
         return payload;
     }
 
@@ -55,7 +59,7 @@ public class TransactionTest {
         PrivateKey key = PrivateKey.createNew(crypto);
 
         Transaction t = new TransactionBuilder()
-                .payload(randomBytes(100))
+                .output(randomBytes(100))
                 .endorse(key)
                 .build();
 
@@ -68,7 +72,7 @@ public class TransactionTest {
         PrivateKey key2 = PrivateKey.createNew(crypto);
 
         Transaction t = new TransactionBuilder()
-                .payload(randomBytes(100))
+                .output(randomBytes(100))
                 .endorse(key1)
                 .build();
 


### PR DESCRIPTION
## Motivation
This PR adds the possibility to reference previous transactions, and use an UTXO model. This is not enforced, it is possible to use only the first output, and use only one payload as it was before.

## How Has This Been Tested?
Unit tests has been run.

## Checklist:
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests

Signed-off-by: Zsolt Szilagyi <zsolt@digitalasset.com>