### PR TITLE
Add default value to previous block hash

### DIFF
--- a/api/src/main/java/org/hyperledger/api/HLAPIBlock.java
+++ b/api/src/main/java/org/hyperledger/api/HLAPIBlock.java
@@ -35,7 +35,7 @@ public class HLAPIBlock extends Block {
     public static class Builder {
         int height;
 
-        protected BID previousHash;
+        protected BID previousHash = BID.INVALID;
         protected MerkleRoot merkleRoot;
         protected int createTime;
         protected List<MerkleTreeNode> transactions = new ArrayList<>();

--- a/api/src/main/java/org/hyperledger/block/HeaderBuilder.java
+++ b/api/src/main/java/org/hyperledger/block/HeaderBuilder.java
@@ -19,7 +19,7 @@ import org.hyperledger.merkletree.MerkleRoot;
 
 public abstract class HeaderBuilder<T extends HeaderBuilder<T>> {
     protected int version;
-    protected BID previousID;
+    protected BID previousID = BID.INVALID;
     protected MerkleRoot merkleRoot = MerkleRoot.INVALID;
     protected int createTime;
     protected int difficultyTarget;


### PR DESCRIPTION
Add default value to previous block hash in builders, the invalid hash is better than initiailizing it with null.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests

Signed-off-by: Zsolt Szilagyi <zsolt@digitalasset.com>

